### PR TITLE
SCHED-103: Design and create Courses page

### DIFF
--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { NavBarAdmin } from '../components/navbar';
+import 'bootstrap/dist/css/bootstrap.css';
+import '../components/Homepage/homepage.css';
+import { Table } from 'antd';
+
+export const Courses: React.FC = () => {
+  const [courses, setCourses] = useState([]);
+
+  useEffect(() => {
+    const fetchCourses = async () => {
+      try {
+        const token = localStorage.getItem('jwt');
+        const response = await axios.get('http://localhost:8000/courses', {
+          headers: {
+            'Content-Type': 'text/plain',
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        setCourses(response.data);
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    };
+
+    fetchCourses();
+  }, []);
+
+  const columns = [
+    {
+      title: 'Course Name',
+      dataIndex: 'name',
+      key: 'name',
+    },
+    {
+      title: 'Course Code',
+      dataIndex: 'code',
+      key: 'code',
+    },
+    {
+      title: 'Professor',
+      dataIndex: 'professor',
+      key: 'professor',
+    },
+    {
+      title: 'Semester',
+      dataIndex: 'semester',
+      key: 'semester',
+    },
+  ];
+
+  return (
+    <div>
+      <NavBarAdmin />
+      <div className='con d-flex flex-row justify-content-between'>
+        <h1 className='hea_1'>Courses</h1>
+      </div>
+      <Table dataSource={courses} columns={columns} />
+    </div>
+  );
+};


### PR DESCRIPTION
# SCHED-103 Pull Request

Author: Elizabeth Vellethara
Type: feature addition

## Purpose

Creates a Courses page that fetches a list of courses from an API and displays them in a table, similar to the way the Professors are being displayed in the "NewPreferences.tsx" page. Assuming the API returns an array of course objects that each contain a name, code, professor, and semester property.