### PR TITLE
GitHub Issue-41: Fixed bug with invalid form state

### DIFF
--- a/src/pages/ProfPreferencePage.tsx
+++ b/src/pages/ProfPreferencePage.tsx
@@ -124,7 +124,7 @@ export const ProfPreferencePage: React.FC = () => {
 
                     <Form.Item {...tailFormItemLayout}>
                         <div style={{ width: '200px', display: 'flex', flexDirection: 'row', justifyContent: 'center', marginBottom: 20 }}>
-                            <Button type='primary' htmlType='reset' style={{ backgroundColor: '#2c2a2a', color: '#ffffff', borderRadius: 32 }}>
+                            <Button type='primary' htmlType='reset' style={{ backgroundColor: '#2c2a2a', color: '#ffffff', borderRadius: 32 }} onClick={() => setFormDisabled(false)}>
                                 CLEAR
                             </Button>
                         </div>


### PR DESCRIPTION
# GitHub Issue-41 Pull Request

Author: Erik 
Type: Bug fix

## Purpose

Fix bug where setting 'Able to teach' to 'No' then selecting 'Clear' would put the form in an invalid state where 'Able to teach' would be set to 'Yes' but the rest of the form would be disabled.

## Screenshots

New:
![image](https://github.com/SENG-499-Company2-B01/Frontend/assets/43917961/49527822-dbab-4097-849e-97112c5abc95)
Old:
![Screenshot 2023-07-15 184717](https://github.com/SENG-499-Company2-B01/Frontend/assets/43917961/71c9d3ab-bd31-45bf-96c1-e902b548150a)

