### PR TITLE
Added modals to confirm logout, and save preferences

### DIFF
--- a/src/components/atoms/Dropdown_menu.tsx
+++ b/src/components/atoms/Dropdown_menu.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { css } from '@emotion/react'
 import styled from '@emotion/styled'
-import { H7 } from './typography'
-import { SimpleLink } from './navLink'
+import { Modal } from 'antd'
+import { useNavigate } from 'react-router-dom'
 
 export const DropdownContainer = styled.div`
     display: inline-block;
@@ -56,8 +55,18 @@ export const DropdownMenuItem = styled.button`
     }
 `
 
-export const ProfileDropdown = (props: { name: string | null }) => {
+interface ProfileDropdownProps {
+    name: string | null
+    onPreferencesPage?: boolean
+    onPreferencesPageCallback?: (callback: () => void) => Promise<void>
+}
+
+export const ProfileDropdown = (props: ProfileDropdownProps) => {
+    const navigate = useNavigate()
+
     const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+    const [confirmLogoutOpen, setConfirmLogoutOpen] = useState(false)
+    const [secondConfirmationOpen, setSecondConfirmationOpen] = useState(false)
     const dropdownRef = useRef<HTMLInputElement>(null)
     const { name } = props
 
@@ -81,17 +90,43 @@ export const ProfileDropdown = (props: { name: string | null }) => {
         setIsDropdownOpen(!isDropdownOpen)
     }
 
+    const handleConfirmLogout = () => {
+        setConfirmLogoutOpen(false)
+        if (props.onPreferencesPage) {
+            setSecondConfirmationOpen(true)
+        } else {
+            logout()
+        }
+    }
+
+    const handleSecondConfirmation = () => {
+        setSecondConfirmationOpen(false)
+        if (props.onPreferencesPageCallback) props.onPreferencesPageCallback(logout)
+    }
+
+    const logout = () => {
+        localStorage.removeItem('jwt')
+        localStorage.removeItem('username')
+        localStorage.removeItem('user')
+        localStorage.removeItem('status')
+        navigate('/logout')
+    }
+
     return (
         <DropdownContainer>
+            <Modal title='Confirm Logout' open={confirmLogoutOpen} onOk={handleConfirmLogout} onCancel={() => setConfirmLogoutOpen(false)} okText='Logout'>
+                <p>Are you sure you want to logout?</p>
+            </Modal>
+            <Modal title='Save Preferences' open={secondConfirmationOpen} onOk={handleSecondConfirmation} onCancel={() => setSecondConfirmationOpen(false)} cancelText='Logout' okText='Save and Logout'>
+                <p>Would you like to save your in progress preferences?</p>
+            </Modal>
             <ProfileButton onClick={toggleDropdown}>{name}</ProfileButton>
             {isDropdownOpen && (
                 <DropdownMenu ref={dropdownRef}>
                     <DropdownMenuItem>Profile</DropdownMenuItem>
                     <DropdownMenuItem>Notifications</DropdownMenuItem>
                     <DropdownMenuItem>Account settings</DropdownMenuItem>
-                    <SimpleLink to='/logout'>
-                        <DropdownMenuItem>Sign out</DropdownMenuItem>
-                    </SimpleLink>
+                    <DropdownMenuItem onClick={() => setConfirmLogoutOpen(true)}>Sign out</DropdownMenuItem>
                 </DropdownMenu>
             )}
         </DropdownContainer>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -53,7 +53,12 @@ export const goToTop = () => {
     })
 }
 
-export const NavBarProf = () => {
+interface NavBarProfProps {
+    onPreferencesPage?: boolean
+    onPreferencePageCallback?: (callback: () => void) => Promise<void>
+}
+
+export const NavBarProf = (props: NavBarProfProps) => {
     const username = localStorage.getItem('username')
     return (
         <StickyContainer>
@@ -66,7 +71,7 @@ export const NavBarProf = () => {
                         <H7>SCHEDULING PREFERENCES</H7>
                     </NavUnlisted>
                     <UserWrapper>
-                        <ProfileDropdown name={String(username).toUpperCase()} />
+                        <ProfileDropdown name={String(username).toUpperCase()} onPreferencesPage={props.onPreferencesPage} onPreferencesPageCallback={props.onPreferencePageCallback} />
                         <ProfileWrapper src={userProfile} />
                     </UserWrapper>
                 </LinkDiv>

--- a/src/pages/ProfPreferencePage.tsx
+++ b/src/pages/ProfPreferencePage.tsx
@@ -57,6 +57,10 @@ export const ProfPreferencePage: React.FC = () => {
 
     const submit = async (e: SyntheticEvent) => {
         e.preventDefault()
+        submitForm()
+    }
+
+    const submitForm = async (fromCallback?: boolean) => {
         const username = localStorage.getItem('username')
 
         const url = process.env.REACT_APP_BACKEND_URL + '/users/' + username
@@ -84,7 +88,7 @@ export const ProfPreferencePage: React.FC = () => {
         console.log(body)
         console.log(numberOfClasses)
         console.log(localStorage)
-        setNavigate(true)
+        if (!fromCallback) setNavigate(true)
     }
 
     if (navigate) {
@@ -131,9 +135,14 @@ export const ProfPreferencePage: React.FC = () => {
         setNumberOfClasses(value!)
     }
 
+    const onLogoutButWantsToSave = async (callback: () => void) => {
+        await submitForm(true)
+        callback()
+    }
+
     return (
         <div>
-            <NavBarProf />
+            <NavBarProf onPreferencesPage onPreferencePageCallback={onLogoutButWantsToSave} />
             <div className='cen'>
                 <H2>Preference</H2>
                 <Form {...formItemLayout} form={form} name='ableToTeachPreference' onFinish={onFinish} style={{ maxWidth: 600 }} scrollToFirstError>


### PR DESCRIPTION
Completes TA test cases 15 and 20

Author: Erik
Type: Feature Addition

## Purpose

Adds a modal to confirm logout.

If the user is editing their preferences adds a second modal to see if they would like to save the preferences.

## Screenshots

![image](https://github.com/SENG-499-Company2-B01/Frontend/assets/43917961/2a541f6e-3491-4459-9246-289e78acdd9f)
![image](https://github.com/SENG-499-Company2-B01/Frontend/assets/43917961/8a1a256a-f64a-44ac-b9b0-a76237d74103)
